### PR TITLE
Ability to override setters in deserializer

### DIFF
--- a/README.md
+++ b/README.md
@@ -427,6 +427,18 @@ class Customer < De::Ser::Ializer
 end
 ```
 
+Setters can also be overridden:
+
+```ruby
+class Customer < De::Ser::Ializer
+  string :name
+
+  def self.name=(object, value)
+    object.name = value.delete_suffix('Part 2')
+  end
+end
+```
+
 Attributes can also use a different name by passing the original method or accessor with a proc shortcut:
 
 ```ruby

--- a/lib/de/ser/ializer.rb
+++ b/lib/de/ser/ializer.rb
@@ -52,6 +52,14 @@ module De
 
         private
 
+        def add_attribute(field)
+          super
+
+          define_singleton_method field.setter do |object, parsed_value|
+            object.public_send(field.setter, parsed_value)
+          end
+        end
+
         def parse_field(object, field, value)
           return if value.nil?
 
@@ -59,7 +67,7 @@ module De
 
           return if parsed_value.nil?
 
-          object.public_send(field.setter, parsed_value)
+          public_send(field.setter, object, parsed_value)
         end
 
         def ostruct?(model_class)

--- a/lib/ializer/version.rb
+++ b/lib/ializer/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ializer
-  VERSION = '0.10.2'
+  VERSION = '0.11.0'
 end

--- a/spec/de/ser/ializer_spec.rb
+++ b/spec/de/ser/ializer_spec.rb
@@ -142,6 +142,13 @@ RSpec.describe De::Ser::Ializer do
 
       expect(parsed.string_prop).to eq order.string_prop
     end
+
+    it 'parses using overridden setter' do
+      data = OverriddenSetterPropertyDeSer.serialize(order)
+      parsed = OverriddenSetterPropertyDeSer.parse(data, TestOrder)
+
+      expect(parsed.decimal_prop).to eq order.decimal_prop * 2
+    end
   end
 
   describe 'PropertySerializer' do

--- a/spec/support/deser/property_de_ser.rb
+++ b/spec/support/deser/property_de_ser.rb
@@ -29,3 +29,9 @@ end
 class CustomeSetterPropertyDeSer < PropertyDeSer
   property :string_prop, setter: :setter_string_prop
 end
+
+class OverriddenSetterPropertyDeSer < PropertyDeSer
+  def self.decimal_prop=(object, value)
+    object.decimal_prop = value * 2
+  end
+end


### PR DESCRIPTION
The use case is we want to use a custom setter to transform the parsed value but encapsulate the logic in the deserializer instead of adding a new setter to the object.