### PR TITLE
require active_support to allow activesupport 7 compatibility

### DIFF
--- a/lib/ializer/time_de_ser.rb
+++ b/lib/ializer/time_de_ser.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/time'
 
 module Ializer

--- a/lib/ser/ializer.rb
+++ b/lib/ser/ializer.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require 'active_support'
 require 'active_support/hash_with_indifferent_access'
 require 'active_support/core_ext/hash'
 


### PR DESCRIPTION
hi @jsteinberg 👋 , hope you're doing well lol

at some point, around rails 4, cherry-picking active support modules added the requirement that `require 'active_support'` precede the cherry-picked library. activesupport 7 expects this now and will error out otherwise.

https://guides.rubyonrails.org/active_support_core_extensions.html#cherry-picking-a-definition

```
/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/core_ext/array/conversions.rb:108:in `<class:Array>': undefined method `deprecator' for module ActiveSupport (NoMethodError)

  deprecate to_default_s: :to_s, deprecator: ActiveSupport.deprecator
                                                          ^^^^^^^^^^^
Did you mean?  deprecate_constant
        from /Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/core_ext/array/conversions.rb:8:in `<top (required)>'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/duration.rb:3:in `<top (required)>'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/core_ext/time/calculations.rb:3:in `<top (required)>'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/core_ext/time.rb:4:in `<top (required)>'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/activesupport-7.1.3.2/lib/active_support/time.rb:12:in `<top (required)>'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ializer-0.14.0/lib/ializer/time_de_ser.rb:3:in `<top (required)>'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from /Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/gems/3.3.0/gems/ializer-0.14.0/lib/ializer.rb:18:in `<top (required)>'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
        from <internal:/Users/Kevin.Tung@tastytrade.com/.rbenv/versions/3.3.0/lib/ruby/3.3.0/rubygems/core_ext/kernel_require.rb>:37:in `require'
```